### PR TITLE
docs: correct `translations.js` example reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository collects community maintained translations for [bpmn-js](https:/
 
 ## Use a Translation
 
-Follow along the [i18n example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/i18n) and replace the [`translations.js` stub](https://github.com/bpmn-io/bpmn-js-examples/blob/master/i18n/app/customTranslate/translations.js) with one of the language files in this repository.
+Follow along the [i18n example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/i18n) and replace the [`translations.js` stub](https://github.com/bpmn-io/bpmn-js-examples/blob/main/i18n/src/customTranslate/translations.js) with one of the language files in this repository.
 
 
 ## Contributing


### PR DESCRIPTION
This broke with the unification of our bpmn-js-examples (https://github.com/bpmn-io/bpmn-js-examples/pull/263).